### PR TITLE
Bump to renamed CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 # Test eap action for Github Actions
+
 An action for Github Actions to verify the validity of an .eap package for Axis ACAP in CI/CD pipelines. Use this after building an ACAP in your ci/cd pipelines to verify that the file was correctly build. The goal with the verification is not to verify the behaviour of the application, but rather to verify that it is correctly built and will be capable of running in a camera.
 
-This action assumes the FApp CLI is installed, see the [install-fappcli-action](https://github.com/fixedit-ai/install-fappcli-action).
+This action assumes the FixedIT CLI is installed, see the [install-fixeditcli-action](https://github.com/fixedit-ai/install-fixeditcli-action).
 
 Example output from a job that fails when the application was not built for the expected architecture:
 ![cicd screenshot](https://github.com/fixedit-ai/test-eap-action/blob/images/images/screenshot.png?raw=true)
 
+## Arguments
+
+Most of the CLI arguments for the FixedIT CLI tool is exposed in this action, see the definition in the [action.yml file](./action.yml). Note that you can also specify the arguments in a `fixedit-manifest.json` file.
+
 ## Example
-This GitHUb Actions CI/CD job will build the ACAP application with the [build-eap-action](https://github.com/fixedit-ai/build-eap-action). After the application is built the `test-eap-action` is used to validate the .eap file that was produced by the build.
+
+As an example, the following GitHub Actions CI/CD job will build the ACAP application with the [build-eap-action](https://github.com/fixedit-ai/build-eap-action). After the application is built the `test-eap-action` is used to validate the .eap file that was produced by the build.
 
 ```yaml
 name: Build hello world ACAP
@@ -17,28 +23,39 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         arch: ["armv7hf", "aarch64"]
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Install FApp CLI and login
-        uses: fixedit-ai/install-fappcli-action@main
+      - name: Install FixedIT CLI and login
+        uses: fixedit-ai/install-fixeditcli-action@v2
         with:
-          token: ${{ secrets.FAPP_TOKEN }}
+          token: ${{ secrets.FIXEDIT_TOKEN }}
 
       - name: Build ACAP application
-        uses: fixedit-ai/build-eap-action@main
+        uses: fixedit-ai/build-eap-action@v2
         with:
           arch: ${{ matrix.arch }}
           dir: hello_world
 
       - name: Validate the content of the ACAP .eap file
-        uses: fixedit-ai/test-eap-action@main
+        uses: fixedit-ai/test-eap-action@v2
         with:
           arch: ${{ matrix.arch }}
           app-path: "hello_world/*.eap"
 ```
+
+## Release notes
+
+### v2
+
+- Bumped the CLI to the new renamed `fixeditcli`. This action is compatible with `fixedit-ai/install-fixeditcli-action` v2 or later.
+- Added more CLI options as arguments to the action.
+
+### v1
+
+First stable release using `FApp CLI`.

--- a/action.yml
+++ b/action.yml
@@ -3,11 +3,26 @@ description: "Validate the content of an .eap package for Axis ACAP"
 
 inputs:
   app-path:
-    description: "The path to the app to test"
+    description: "The path to the app to test."
     default: "*.eap"
   arch:
-    description: "The expected architecture"
+    description: "The expected architecture (e.g., aarch64, armv7hf, all)."
     default: ""
+  no-manifest-ok:
+    description: "Accept packages without a manifest.json file."
+    default: "false"
+  ignore-file-name:
+    description: "Ignore file name validation."
+    default: "false"
+  ignore-other-elf-files:
+    description: "Ignore checking ELF files other than the app binary."
+    default: "false"
+  allow-special-files:
+    description: "Allow special files such as FIFO, sockets, etc. in the EAP file."
+    default: "false"
+  strict:
+    description: "Treat warnings as errors."
+    default: "true"
 
 runs:
   using: "composite"
@@ -15,5 +30,15 @@ runs:
     - name: Test application
       shell: bash
       run: |
+        # Construct the ARCH argument
         ARCH_ARG=`[[ -n "${{ inputs.arch }}" ]] && echo "--arch ${{ inputs.arch }}" || echo ""`
-        fappcli-test -vv ${{ inputs.app-path }} $ARCH_ARG
+
+        # Construct additional flags based on inputs
+        MANIFEST_ARG=`[[ "${{ inputs.no-manifest-ok }}" == "true" ]] && echo "--no-manifest-ok" || echo ""`
+        IGNORE_FILENAME_ARG=`[[ "${{ inputs.ignore-file-name }}" == "true" ]] && echo "--ignore-file-name" || echo ""`
+        IGNORE_ELF_ARG=`[[ "${{ inputs.ignore-other-elf-files }}" == "true" ]] && echo "--ignore-other-elf-files" || echo ""`
+        ALLOW_SPECIAL_ARG=`[[ "${{ inputs.allow-special-files }}" == "true" ]] && echo "--allow-special-files" || echo ""`
+        STRICT_ARG=`[[ "${{ inputs.strict }}" == "true" ]] && echo "--strict" || echo ""`
+
+        # Run the command with all the constructed arguments
+        fixeditcli-test -vv ${{ inputs.app-path }} $ARCH_ARG $MANIFEST_ARG $IGNORE_FILENAME_ARG $IGNORE_ELF_ARG $ALLOW_SPECIAL_ARG $STRICT_ARG


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the README.md to reflect the renaming of "FApp CLI" to "FixedIT CLI."
	- Enhanced installation instructions and example job configurations, specifying `ubuntu-24.04` as the runner.
	- Introduced a "Release notes" section detailing version changes and new CLI options.
  
- **New Features**
	- Added new input parameters in action.yml for improved customization during the testing process, enhancing flexibility.
	- Updated command execution logic to replace `fappcli-test` with `fixeditcli-test`, incorporating new arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->